### PR TITLE
Only notify of latest on first check

### DIFF
--- a/src/main/kotlin/watch/dependency/appAwait.kt
+++ b/src/main/kotlin/watch/dependency/appAwait.kt
@@ -19,7 +19,7 @@ class DependencyAwait(
 			val versions = mavenRepository.versions(coordinate)
 			debug.log { "$coordinate $versions" }
 
-			if (version in versions) {
+			if (versions != null && version in versions.all) {
 				break
 			}
 

--- a/src/main/kotlin/watch/dependency/appNotify.kt
+++ b/src/main/kotlin/watch/dependency/appNotify.kt
@@ -29,10 +29,17 @@ class DependencyNotify(
 						val versions = mavenRepository.versions(coordinates)
 						debug.log { "$coordinates $versions" }
 
-						for (mavenVersion in versions) {
-							if (!database.coordinatesSeen(coordinates, mavenVersion)) {
-								database.markCoordinatesSeen(coordinates, mavenVersion)
-								notifier.notify(coordinates, mavenVersion)
+						if (versions != null) {
+							val notifyVersions = if (database.coordinateSeen(coordinates)) {
+								versions.all.filterNot { database.coordinateVersionSeen(coordinates, it) }
+							} else {
+								listOf(versions.latest)
+							}
+							for (mavenVersion in versions.all) {
+								database.markCoordinateVersionSeen(coordinates, mavenVersion)
+							}
+							for (version in notifyVersions) {
+								notifier.notify(coordinates, version)
 							}
 						}
 					}

--- a/src/main/kotlin/watch/dependency/database.kt
+++ b/src/main/kotlin/watch/dependency/database.kt
@@ -4,42 +4,56 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 interface Database {
-	fun coordinatesSeen(coordinate: MavenCoordinate, version: String): Boolean
-	fun markCoordinatesSeen(coordinate: MavenCoordinate, version: String)
+	fun coordinateSeen(coordinate: MavenCoordinate): Boolean
+	fun coordinateVersionSeen(coordinate: MavenCoordinate, version: String): Boolean
+	fun markCoordinateVersionSeen(coordinate: MavenCoordinate, version: String)
 }
 
 class InMemoryDatabase : Database {
 	private val seenVersions = mutableMapOf<MavenCoordinate, MutableSet<String>>()
 
-	override fun coordinatesSeen(coordinate: MavenCoordinate, version: String): Boolean {
+	override fun coordinateSeen(coordinate: MavenCoordinate): Boolean {
+		return coordinate in seenVersions
+	}
+
+	override fun coordinateVersionSeen(coordinate: MavenCoordinate, version: String): Boolean {
 		return seenVersions[coordinate]?.contains(version) ?: false
 	}
 
-	override fun markCoordinatesSeen(coordinate: MavenCoordinate, version: String) {
+	override fun markCoordinateVersionSeen(coordinate: MavenCoordinate, version: String) {
 		seenVersions.getOrPut(coordinate, ::LinkedHashSet) += version
 	}
 }
 
 class FileSystemDatabase(private val root: Path) : Database {
-	private fun path(coordinate: MavenCoordinate, version: String): Path {
+	private fun path(coordinate: MavenCoordinate): Path {
 		return root.resolve(coordinate.groupId.replace(".", root.fileSystem.separator))
 			.resolve(coordinate.artifactId)
-			.resolve("$version.txt")
 	}
 
-	override fun coordinatesSeen(
+	private fun path(coordinate: MavenCoordinate, version: String): Path {
+		return path(coordinate).resolve("$version.txt")
+	}
+
+	override fun coordinateSeen(coordinate: MavenCoordinate): Boolean {
+		return Files.exists(path(coordinate))
+	}
+
+	override fun coordinateVersionSeen(
 		coordinate: MavenCoordinate,
 		version: String
 	): Boolean {
 		return Files.exists(path(coordinate, version))
 	}
 
-	override fun markCoordinatesSeen(
+	override fun markCoordinateVersionSeen(
 		coordinate: MavenCoordinate,
 		version: String
 	) {
 		val path = path(coordinate, version)
-		Files.createDirectories(path.parent)
-		Files.createFile(path)
+		if (Files.notExists(path)) {
+			Files.createDirectories(path.parent)
+			Files.createFile(path)
+		}
 	}
 }

--- a/src/main/kotlin/watch/dependency/util.kt
+++ b/src/main/kotlin/watch/dependency/util.kt
@@ -16,6 +16,8 @@ inline fun Path.readText(): String {
 	return Files.readAllBytes(this).decodeToString()
 }
 
+class HttpException(val code: Int, message: String) : RuntimeException("$code $message")
+
 suspend fun Call.await(): String {
 	return suspendCancellableCoroutine { continuation ->
 		enqueue(object : Callback {
@@ -26,7 +28,7 @@ suspend fun Call.await(): String {
 						continuation.resume(body)
 					} else {
 						continuation.resumeWithException(
-							IOException("HTTP ${response.code} ${response.message}")
+							HttpException(response.code, response.message)
 						)
 					}
 				}

--- a/src/test/kotlin/watch/dependency/DatabaseTest.kt
+++ b/src/test/kotlin/watch/dependency/DatabaseTest.kt
@@ -18,10 +18,24 @@ class DatabaseTest(
 	@Test fun returnsTrueAfterMark() {
 		val exampleCoordinates = MavenCoordinate("com.example", "example")
 
-		assertFalse(database.coordinatesSeen(exampleCoordinates, "1.0.0"))
+		assertFalse(database.coordinateSeen(exampleCoordinates))
+		assertFalse(database.coordinateVersionSeen(exampleCoordinates, "1.0.0"))
 
-		database.markCoordinatesSeen(exampleCoordinates, "1.0.0")
-		assertTrue(database.coordinatesSeen(exampleCoordinates, "1.0.0"))
+		database.markCoordinateVersionSeen(exampleCoordinates, "1.0.0")
+		assertTrue(database.coordinateSeen(exampleCoordinates))
+		assertTrue(database.coordinateVersionSeen(exampleCoordinates, "1.0.0"))
+	}
+
+	@Test fun markingSeenIsIdempotent() {
+		val exampleCoordinates = MavenCoordinate("com.example", "example")
+
+		database.markCoordinateVersionSeen(exampleCoordinates, "1.0.0")
+		assertTrue(database.coordinateSeen(exampleCoordinates))
+		assertTrue(database.coordinateVersionSeen(exampleCoordinates, "1.0.0"))
+
+		database.markCoordinateVersionSeen(exampleCoordinates, "1.0.0")
+		assertTrue(database.coordinateSeen(exampleCoordinates))
+		assertTrue(database.coordinateVersionSeen(exampleCoordinates, "1.0.0"))
 	}
 
 	companion object {

--- a/src/test/kotlin/watch/dependency/FakeMavenRepository.kt
+++ b/src/test/kotlin/watch/dependency/FakeMavenRepository.kt
@@ -1,18 +1,24 @@
 package watch.dependency
 
+import watch.dependency.MavenRepository.Versions
+
 class FakeMavenRepository : MavenRepository {
-	private val versions = mutableMapOf<MavenCoordinate, MutableSet<String>>()
+	private val versions = mutableMapOf<MavenCoordinate, MutableList<String>>()
 
 	fun addArtifact(
 		coordinate: MavenCoordinate,
 		version: String,
 	) {
-		versions.getOrPut(coordinate, ::LinkedHashSet).add(version)
+		versions.getOrPut(coordinate, ::ArrayList).add(version)
 	}
 
 	override suspend fun versions(
 		coordinate: MavenCoordinate,
-	): Set<String> {
-		return versions[coordinate] ?: emptySet()
+	): Versions? {
+		val coordinateVersions = versions[coordinate] ?: return null
+		return Versions(
+			latest = coordinateVersions.last(),
+			all = coordinateVersions.toSet(),
+		)
 	}
 }


### PR DESCRIPTION
This prevents spamming of tens or hundreds of versions on a new coordinate set being added.

Also properly handle 404s when there are no versions for a coordinate.

Closes #3. 