### PR TITLE
Add support for watching multiple repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,34 @@ Pipe to a notification, email, HTTP request, sound, or anything else your heart 
 
 The `notify` subcommand allows you to monitor multiple groupId/artifactId coordinates at once.
 
-Create a `config.yaml` with a coordinate list.
-```yaml
-coordinates:
- - com.example:example
- - com.jakewharton:dependency-watch
+Create a `config.toml` with a coordinate list.
+```toml
+[MavenCentral]
+coordinates = [
+  "com.example:example",
+  "com.jakewharton:dependency-watch",
+]
 ```
 
-Pass the config file and a `--data` directory to store already-seen versions:
+You can also monitor Google's maven repository with the table name "GoogleMaven".
+Monitor custom repositories by adding a 'host' key and optional 'name'.
+
+```toml
+[CustomRepo]
+name = "Custom Repo" # Optional!
+host = "https://example.com/repo/"
+coordinates = [
+  "com.example:thing",
+]
+```
+
+Pass the config file and a `--data` directory to store already-seen versions across invocations:
 ```
 $ dependency-watch notify --data data config.yaml
 ```
 
-This will check for any new versions once and then exit. Run with `--watch` to continuously check
-every minute. Use `--interval` to adjust the check period.
+The `notify` subcommand will check for any new versions once and then exit.
+Run with `--watch` to continuously check every minute. Use `--interval` to adjust the check period.
 
 ### IFTTT
 
@@ -37,9 +51,9 @@ found. This notification can then be redirected to Twitter, Slack, email, printe
 light bulbs, and hundreds of other places.
 
 The event will have the following data set:
- - `Value1`: The groupId:artifactId pair (e.g., `com.example:example`)
- - `Value2`: The new versions that was seen (e.g., `1.1.0`)
- - `Value3`: Not used
+ - `Value1`: The maven repository name
+ - `Value2`: The groupId:artifactId pair (e.g., `com.example:example`)
+ - `Value3`: The new versions that was seen (e.g., `1.1.0`)
 
 
 ## Install
@@ -115,15 +129,16 @@ Commands:
 $ dependency-watch await --help
 Usage: dependency-watch await [OPTIONS] COORDINATES
 
-  Wait for an artifact to appear on Maven central then exit
+  Wait for an artifact to appear in a Maven repository then exit
 
 Options:
   --interval DURATION  Amount of time between checks in ISO8601 duration
                        format (default 1 minute)
   --ifttt URL          IFTTT webhook URL to trigger (see
                        https://ifttt.com/maker_webhooks)
-  --repo URL           URL of maven repository to check (default is Maven
-                       Central)
+  --repo URL           URL or well-known ID of maven repository to check
+                       (default is "MavenCentral"). Available well-known IDs:
+                       "MavenCentral", "GoogleMaven".
   -h, --help           Show this message and exit
 
 Arguments:
@@ -131,29 +146,46 @@ Arguments:
 ```
 ```
 $ dependency-watch notify --help
-Usage: dependency-watch notify [OPTIONS] [CONFIG]...
+Usage: dependency-watch notify [OPTIONS] CONFIG
 
-  Monitor Maven coordinates for new versions
+  Monitor Maven coordinates in a Maven repository for new versions
 
 Options:
-  --data PATH          Directory into which already-seen versions are tracked
-                       (default in-memory)
   --interval DURATION  Amount of time between checks in ISO8601 duration
                        format (default 1 minute)
   --ifttt URL          IFTTT webhook URL to trigger (see
                        https://ifttt.com/maker_webhooks)
+  --data PATH          Directory into which already-seen versions are tracked
+                       (default in-memory)
   --watch              Continually monitor for new versions every '--interval'
   -h, --help           Show this message and exit
 
 Arguments:
-  CONFIG  YAML file containing list of coordinates to watch
+  CONFIG  TOML file containing repositories and coordinates to watch
 
           Format:
 
-          repository: https://custom.repo/  # Optional! Default: Maven Central
-          coordinates:
-           - com.example.ping:pong
-           - com.example.fizz:buzz
+          [MavenCentral]
+          coordinates = [
+            "com.example.ping:pong",
+            "com.example.fizz:buzz",
+          ]
+
+          [GoogleMaven]
+          coordinates = [
+            "com.google:example",
+          ]
+
+          [CustomRepo]
+          name = "Custom Repo"  # Optional
+          host = "https://example.com/repo/"
+          coordinates = [
+            "com.example:thing",
+          ]
+
+          "MavenCentral" and "GoogleMaven" are two optional well-known
+          repositories which only require a list of coordinates. Other
+          repositories also require a host and can specify an optional name.
 ```
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 	implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
 	implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVersion"
 	implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion"
-	implementation 'com.charleskorn.kaml:kaml:0.40.0'
+	implementation 'org.tomlj:tomlj:1.0.0'
 	implementation "io.github.pdvrieze.xmlutil:core:$xmlUtilVersion"
 	implementation "io.github.pdvrieze.xmlutil:serialization:$xmlUtilVersion"
 	implementation 'com.github.ajalt.clikt:clikt:3.4.0'
@@ -34,6 +34,7 @@ dependencies {
 	testImplementation 'com.google.jimfs:jimfs:1.2'
 	testImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"
 	testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0'
+	testImplementation 'org.jetbrains.kotlin:kotlin-test'
 }
 
 repositories {

--- a/src/main/kotlin/watch/dependency/config.kt
+++ b/src/main/kotlin/watch/dependency/config.kt
@@ -1,39 +1,101 @@
 package watch.dependency
 
-import com.charleskorn.kaml.Yaml
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.PrimitiveKind.STRING
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 import okhttp3.HttpUrl
-import watch.dependency.HttpMaven2Repository.Companion.MavenCentral
-import watch.dependency.HttpMaven2Repository.Companion.parseWellKnownMavenRepositoryNameOrUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.tomlj.Toml
+import org.tomlj.TomlTable
+import watch.dependency.RepositoryConfig.Companion.GoogleMavenHost
+import watch.dependency.RepositoryConfig.Companion.GoogleMavenId
+import watch.dependency.RepositoryConfig.Companion.GoogleMavenName
+import watch.dependency.RepositoryConfig.Companion.MavenCentralHost
+import watch.dependency.RepositoryConfig.Companion.MavenCentralId
+import watch.dependency.RepositoryConfig.Companion.MavenCentralName
+import watch.dependency.RepositoryType.Maven2
 
-@Serializable
-data class Config(
-	@Serializable(WellKnownRepositoryNameOrUrl::class)
-	val repository: HttpUrl = MavenCentral,
+fun MavenRepository.Factory.parseWellKnownIdOrUrl(value: String): MavenRepository {
+	return when (value) {
+		MavenCentralId -> maven2(MavenCentralName, MavenCentralHost)
+		GoogleMavenId -> maven2(GoogleMavenName, GoogleMavenHost)
+		else -> maven2("Maven Repository", value.toHttpUrl())
+	}
+}
+
+data class RepositoryConfig(
+	val name: String,
+	val host: HttpUrl,
+	val type: RepositoryType = Maven2,
 	val coordinates: List<MavenCoordinate>,
 ) {
 	companion object {
-		private val serializer = Yaml.default
+		const val MavenCentralId = "MavenCentral"
+		const val MavenCentralName = "Maven Central"
+		val MavenCentralHost = "https://repo1.maven.org/maven2/".toHttpUrl()
+		const val GoogleMavenId = "GoogleMaven"
+		const val GoogleMavenName = "Google Maven"
+		val GoogleMavenHost = "https://maven.google.com/".toHttpUrl()
+		private const val TomlKeyName = "name"
+		private const val TomlKeyHost = "host"
+		private const val TomlKeyType = "type"
+		private const val TomlKeyCoordinates = "coordinates"
 
-		fun parseFromYaml(value: String): Config {
-			return serializer.decodeFromString(serializer(), value)
+		private fun TomlTable.getCoordinates(key: String): List<MavenCoordinate> {
+			val coordinateArray = getArray(key)!!
+			return (0 until coordinateArray.size())
+				.map(coordinateArray::getString)
+				.map(MavenCoordinate::parse)
+		}
+
+		private fun TomlTable.tryParseWellKnown(self: String, name: String, host: HttpUrl): RepositoryConfig {
+			var coordinates: List<MavenCoordinate>? = null
+			for (key in keySet()) {
+				when (key) {
+					TomlKeyCoordinates -> coordinates = getCoordinates(key)
+					TomlKeyName, TomlKeyHost, TomlKeyType -> {
+						throw IllegalArgumentException("'$self' table must not define a '$key' key")
+					}
+					else -> throw IllegalArgumentException("'$self' table contains unknown '$key' key")
+				}
+			}
+			requireNotNull(coordinates) { "'$self' table missing required '$TomlKeyCoordinates' key" }
+			return RepositoryConfig(name, host, Maven2, coordinates)
+		}
+
+		private fun TomlTable.tryParseCustom(self: String): RepositoryConfig {
+			var name = self
+			var host: HttpUrl? = null
+			var type: RepositoryType = Maven2
+			var coordinates: List<MavenCoordinate>? = null
+			for (key in keySet()) {
+				when (key) {
+					TomlKeyName -> name = getString(key)!!
+					TomlKeyHost -> host = getString(key)!!.toHttpUrl()
+					TomlKeyType -> type = RepositoryType.valueOf(getString(key)!!)
+					TomlKeyCoordinates -> coordinates = getCoordinates(key)
+					else -> throw IllegalArgumentException("'$self' table contains unknown key '$key'")
+				}
+			}
+			requireNotNull(host) { "'$self' table missing required '$TomlKeyHost' key" }
+			requireNotNull(coordinates) { "'$self' table missing required '$TomlKeyCoordinates' key" }
+			return RepositoryConfig(name, host, type, coordinates)
+		}
+
+		fun parseConfigsFromToml(toml: String): List<RepositoryConfig> = buildList {
+			val parseResult = Toml.parse(toml)
+			require(!parseResult.hasErrors()) {
+				"Unable to parse TOML config:\n\n * " + parseResult.errors().joinToString("\n *")
+			}
+			for (key in parseResult.keySet()) {
+				val table = parseResult.getTable(key)!!
+				this += when (key) {
+					MavenCentralId -> table.tryParseWellKnown(MavenCentralId, MavenCentralName, MavenCentralHost)
+					GoogleMavenId -> table.tryParseWellKnown(GoogleMavenId, GoogleMavenName, GoogleMavenHost)
+					else -> table.tryParseCustom(key)
+				}
+			}
 		}
 	}
 }
 
-private object WellKnownRepositoryNameOrUrl : KSerializer<HttpUrl> {
-	override val descriptor = PrimitiveSerialDescriptor("RepositoryName", STRING)
-
-	override fun deserialize(decoder: Decoder): HttpUrl {
-		return parseWellKnownMavenRepositoryNameOrUrl(decoder.decodeString())
-	}
-
-	override fun serialize(encoder: Encoder, value: HttpUrl) {
-		throw UnsupportedOperationException()
-	}
+enum class RepositoryType {
+	Maven2,
 }

--- a/src/main/kotlin/watch/dependency/dependencyAwait.kt
+++ b/src/main/kotlin/watch/dependency/dependencyAwait.kt
@@ -27,6 +27,6 @@ class DependencyAwait(
       delay(checkInterval)
 		}
 
-		versionNotifier.notify(coordinate, version)
+		versionNotifier.notify(mavenRepository.name, coordinate, version)
 	}
 }

--- a/src/test/kotlin/watch/dependency/CompositeVersionNotifierTest.kt
+++ b/src/test/kotlin/watch/dependency/CompositeVersionNotifierTest.kt
@@ -8,7 +8,7 @@ class CompositeVersionNotifierTest {
 	@Test fun notifyEmpty() = runBlocking {
 		val versionNotifier = listOf<VersionNotifier>().flatten()
 
-		versionNotifier.notify(MavenCoordinate("com.example", "example"), "1.0.0")
+		versionNotifier.notify("Repo", MavenCoordinate("com.example", "example"), "1.0.0")
 
 		// Nothing to test!
 	}
@@ -17,10 +17,10 @@ class CompositeVersionNotifierTest {
 		val recording = RecordingVersionNotifier()
 		val notifier = listOf(recording).flatten()
 
-		notifier.notify(MavenCoordinate("com.example", "example"), "1.0.0")
+		notifier.notify("Repo", MavenCoordinate("com.example", "example"), "1.0.0")
 
 		assertThat(recording.notifications).containsExactly(
-			"com.example:example:1.0.0",
+			"Repo com.example:example:1.0.0",
 		)
 	}
 
@@ -29,13 +29,13 @@ class CompositeVersionNotifierTest {
 		val recording2 = RecordingVersionNotifier()
 		val notifier = listOf(recording1, recording2).flatten()
 
-		notifier.notify(MavenCoordinate("com.example", "example"), "1.0.0")
+		notifier.notify("Repo", MavenCoordinate("com.example", "example"), "1.0.0")
 
 		assertThat(recording1.notifications).containsExactly(
-			"com.example:example:1.0.0",
+			"Repo com.example:example:1.0.0",
 		)
 		assertThat(recording2.notifications).containsExactly(
-			"com.example:example:1.0.0",
+			"Repo com.example:example:1.0.0",
 		)
 	}
 }

--- a/src/test/kotlin/watch/dependency/ConfigTest.kt
+++ b/src/test/kotlin/watch/dependency/ConfigTest.kt
@@ -1,0 +1,416 @@
+package watch.dependency
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.tomlj.TomlInvalidTypeException
+import watch.dependency.RepositoryConfig.Companion.GoogleMavenHost
+import watch.dependency.RepositoryConfig.Companion.GoogleMavenName
+import watch.dependency.RepositoryConfig.Companion.MavenCentralHost
+import watch.dependency.RepositoryConfig.Companion.MavenCentralName
+import watch.dependency.RepositoryType.Maven2
+
+class ConfigTest {
+	@Test fun empty() {
+		val expected = emptyList<RepositoryConfig>()
+		val actual = RepositoryConfig.parseConfigsFromToml("")
+		assertEquals(expected, actual)
+	}
+
+	@Test fun mavenCentral() {
+		val expected = listOf(
+			RepositoryConfig(MavenCentralName, MavenCentralHost, Maven2, listOf(
+				MavenCoordinate("com.example", "example-a"),
+				MavenCoordinate("com.example", "example-b"))))
+		val actual = RepositoryConfig.parseConfigsFromToml("""
+			|[MavenCentral]
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		assertEquals(expected, actual)
+	}
+
+	@Test fun mavenCentralNonTableThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|MavenCentral = "foo"
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun mavenCentralNoCoordinatesThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[MavenCentral]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'MavenCentral' table missing required 'coordinates' key")
+	}
+
+	@Test fun mavenCentralNonArrayCoordinatesThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[MavenCentral]
+			|coordinates = "foo"
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun mavenCentralNonStringCoordinatesThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[MavenCentral]
+			|coordinates = [1, 2, 3]
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun mavenCentralNameThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[MavenCentral]
+			|name = "Custom Name"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'MavenCentral' table must not define a 'name' key")
+	}
+
+	@Test fun mavenCentralHostThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[MavenCentral]
+			|host = "https://example.com/"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'MavenCentral' table must not define a 'host' key")
+	}
+
+	@Test fun mavenCentralTypeThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[MavenCentral]
+			|type = "Maven2"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'MavenCentral' table must not define a 'type' key")
+	}
+
+	@Test fun mavenCentralUnknownKeyThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[MavenCentral]
+			|foo = "bar"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'MavenCentral' table contains unknown 'foo' key")
+	}
+
+	@Test fun mavenCentralChildTableThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[MavenCentral]
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|[MavenCentral.Foo]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'MavenCentral' table contains unknown 'Foo' key")
+	}
+
+	@Test fun googleMaven() {
+		val expected = listOf(
+			RepositoryConfig(GoogleMavenName, GoogleMavenHost, Maven2, listOf(
+				MavenCoordinate("com.example", "example-a"),
+				MavenCoordinate("com.example", "example-b"))))
+		val actual = RepositoryConfig.parseConfigsFromToml("""
+			|[GoogleMaven]
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		assertEquals(expected, actual)
+	}
+
+	@Test fun googleMavenNonTableThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|GoogleMaven = "foo"
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun googleMavenNoCoordinatesThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[GoogleMaven]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'GoogleMaven' table missing required 'coordinates' key")
+	}
+
+	@Test fun googleMavenNonArrayCoordinatesThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[GoogleMaven]
+			|coordinates = "foo"
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun googleMavenNonStringCoordinatesThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[GoogleMaven]
+			|coordinates = [1, 2, 3]
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun googleMavenNameThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[GoogleMaven]
+			|name = "Custom Name"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'GoogleMaven' table must not define a 'name' key")
+	}
+
+	@Test fun googleMavenHostThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[GoogleMaven]
+			|host = "https://example.com/"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'GoogleMaven' table must not define a 'host' key")
+	}
+
+	@Test fun googleMavenTypeThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[GoogleMaven]
+			|type = "Maven2"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'GoogleMaven' table must not define a 'type' key")
+	}
+
+	@Test fun googleMavenUnknownKeyThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[GoogleMaven]
+			|foo = "bar"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'GoogleMaven' table contains unknown 'foo' key")
+	}
+
+	@Test fun googleMavenChildTableThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[GoogleMaven]
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|[GoogleMaven.Foo]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'GoogleMaven' table contains unknown 'Foo' key")
+	}
+
+	@Test fun customRepo() {
+		val expected = listOf(
+			RepositoryConfig("CustomRepo", "https://example.com/".toHttpUrl(), Maven2, listOf(
+				MavenCoordinate("com.example", "example-a"),
+				MavenCoordinate("com.example", "example-b"))))
+		val actual = RepositoryConfig.parseConfigsFromToml("""
+			|[CustomRepo]
+			|host = "https://example.com/"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		assertEquals(expected, actual)
+	}
+
+	@Test fun customRepoNonTableThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|CustomRepo = "foo"
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun customRepoWithName() {
+		val expected = listOf(
+			RepositoryConfig("Custom Repo", "https://example.com/".toHttpUrl(), Maven2, listOf(
+				MavenCoordinate("com.example", "example-a"),
+				MavenCoordinate("com.example", "example-b"))))
+		val actual = RepositoryConfig.parseConfigsFromToml("""
+			|[CustomRepo]
+			|name = "Custom Repo"
+			|host = "https://example.com/"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		assertEquals(expected, actual)
+	}
+
+	@Test fun customRepoNonStringNameThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[CustomRepo]
+			|name = 1
+			|host = "https://example.com/"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun customRepoWithType() {
+		val expected = listOf(
+			RepositoryConfig("CustomRepo", "https://example.com/".toHttpUrl(), Maven2, listOf(
+				MavenCoordinate("com.example", "example-a"),
+				MavenCoordinate("com.example", "example-b"))))
+		val actual = RepositoryConfig.parseConfigsFromToml("""
+			|[CustomRepo]
+			|host = "https://example.com/"
+			|type = "Maven2"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		assertEquals(expected, actual)
+	}
+
+	@Test fun customRepoNonStringTypeThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[CustomRepo]
+			|host = "https://example.com/"
+			|type = 1
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun customRepoNoHostThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[CustomRepo]
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'CustomRepo' table missing required 'host' key")
+	}
+
+	@Test fun customRepoNonStringHostThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[CustomRepo]
+			|host = 1
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun customRepoNoCoordinatesThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[CustomRepo]
+			|host = "https://example.com/"
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("'CustomRepo' table missing required 'coordinates' key")
+	}
+
+	@Test fun customRepoNonArrayCoordinatesThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[CustomRepo]
+			|coordinates = "foo"
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun customRepoNonStringCoordinatesThrows() {
+		assertFailsWith<TomlInvalidTypeException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[CustomRepo]
+			|coordinates = [1, 2, 3]
+			|""".trimMargin())
+		}
+	}
+
+	@Test fun customRepoUnknownTypeThrows() {
+		val t = assertFailsWith<IllegalArgumentException> {
+			RepositoryConfig.parseConfigsFromToml("""
+			|[CustomRepo]
+			|host = "https://example.com/"
+			|type = "MavenTwo"
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+		}
+		assertThat(t).hasMessageThat().isEqualTo("No enum constant watch.dependency.RepositoryType.MavenTwo")
+	}
+}

--- a/src/test/kotlin/watch/dependency/DependencyAwaitTest.kt
+++ b/src/test/kotlin/watch/dependency/DependencyAwaitTest.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class DependencyAwaitTest {
-	private val mavenRepository = FakeMavenRepository()
+	private val mavenRepository = FakeMavenRepository("Repo")
 	private val notifier = RecordingVersionNotifier()
 	private val app = DependencyAwait(
 		mavenRepository = mavenRepository,
@@ -32,6 +32,6 @@ class DependencyAwaitTest {
 
 		advanceTimeBy(1.seconds)
 		runCurrent()
-		assertThat(notifier.notifications).containsExactly("com.example:example:1.0")
+		assertThat(notifier.notifications).containsExactly("Repo com.example:example:1.0")
 	}
 }

--- a/src/test/kotlin/watch/dependency/DependencyNotifierTest.kt
+++ b/src/test/kotlin/watch/dependency/DependencyNotifierTest.kt
@@ -5,66 +5,86 @@ import com.google.common.truth.Truth.assertThat
 import kotlin.io.path.writeText
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Test
-import watch.dependency.HttpMaven2Repository.Companion.MavenCentral
+import watch.dependency.RepositoryConfig.Companion.MavenCentralHost
+import watch.dependency.RepositoryConfig.Companion.MavenCentralName
 
 class DependencyNotifierTest {
-	private val config = Jimfs.newFileSystem().rootDirectory.resolve("config.yaml")
+	private val config = Jimfs.newFileSystem().rootDirectory.resolve("config.toml")
 	private val mavenRepositories = mutableMapOf<HttpUrl, FakeMavenRepository>()
 	private val versionNotifier = RecordingVersionNotifier()
 	private val notifier = DependencyNotifier(
-		mavenRepositoryFactory = { mavenRepositories.getOrPut(it, ::FakeMavenRepository) },
+		mavenRepositoryFactory = object : MavenRepository.Factory {
+			override fun maven2(name: String, url: HttpUrl): MavenRepository {
+				return mavenRepositories.getOrPut(url) { FakeMavenRepository(name) }
+			}
+		},
 		database = InMemoryDatabase(),
 		versionNotifier = versionNotifier,
 		configPath = config,
 	)
 
-	@Test fun runOnce() = runTest {
+	@Test fun run() = runTest {
 		config.writeText("""
-			|coordinates:
-			| - com.example:example-a
-		""".trimMargin())
+			|[MavenCentral]
+			|coordinates = [
+			|  "com.example:example-a",
+			|]
+			|""".trimMargin())
 
 		notifier.run()
 		assertThat(versionNotifier.notifications).isEmpty()
 
-		val mavenRepository = mavenRepositories[MavenCentral]!!
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
+		val mavenCentral = mavenRepositories[MavenCentralHost]!!
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
 
 		notifier.run()
 		assertThat(versionNotifier.notifications).containsExactly(
-			"com.example:example-a:1.0",
+			"Maven Central com.example:example-a:1.0",
 		)
 	}
 
-	@Test fun customRepositoryHonored() = runBlocking<Unit> {
+	@Test fun runChecksMultipleRepos() = runTest {
+		val customHost = "https://example.com/".toHttpUrl()
 		config.writeText("""
-			|repository: https://example.com/
-			|coordinates:
-			| - com.example:example-a
-		""".trimMargin())
+			|[MavenCentral]
+			|coordinates = [
+			|  "com.example:example-a",
+			|]
+			|
+			|[CustomRepo]
+			|host = "$customHost"
+			|coordinates = [
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
 
 		notifier.run()
+		assertThat(versionNotifier.notifications).isEmpty()
 
-		val mavenRepository = mavenRepositories["https://example.com/".toHttpUrl()]!!
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
+		val mavenCentral = mavenRepositories[MavenCentralHost]!!
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
+		val customRepository = mavenRepositories[customHost]!!
+		customRepository.addArtifact(MavenCoordinate("com.example", "example-b"), "1.0")
 
 		notifier.run()
 		assertThat(versionNotifier.notifications).containsExactly(
-			"com.example:example-a:1.0",
+			"Maven Central com.example:example-a:1.0",
+			"CustomRepo com.example:example-b:1.0",
 		)
 	}
 
 	@Test fun notifyNotifiesOnceAvailable() = runTest {
 		config.writeText("""
-			|coordinates:
-			| - com.example:example-a
-		""".trimMargin())
+			|[MavenCentral]
+			|coordinates = [
+			|  "com.example:example-a",
+			|]
+			|""".trimMargin())
 
 		val monitorJob = launch {
 			notifier.monitor(5.seconds)
@@ -73,13 +93,50 @@ class DependencyNotifierTest {
 		runCurrent()
 		assertThat(versionNotifier.notifications).isEmpty()
 
-		val mavenRepository = mavenRepositories[MavenCentral]!!
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
+		val mavenCentral = mavenRepositories[MavenCentralHost]!!
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
 
 		advanceTimeBy(5.seconds)
 		runCurrent()
 		assertThat(versionNotifier.notifications).containsExactly(
-			"com.example:example-a:1.0",
+			"Maven Central com.example:example-a:1.0",
+		)
+
+		monitorJob.cancel()
+	}
+
+	@Test fun notifyChecksMultipleReposAndNotifiesOnceAvailable() = runTest {
+		val customHost = "https://example.com/".toHttpUrl()
+		config.writeText("""
+			|[MavenCentral]
+			|coordinates = [
+			|  "com.example:example-a",
+			|]
+			|
+			|[CustomRepo]
+			|host = "$customHost"
+			|coordinates = [
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
+
+		val monitorJob = launch {
+			notifier.monitor(5.seconds)
+		}
+
+		runCurrent()
+		assertThat(versionNotifier.notifications).isEmpty()
+
+		val mavenCentral = mavenRepositories[MavenCentralHost]!!
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
+		val customRepository = mavenRepositories[customHost]!!
+		customRepository.addArtifact(MavenCoordinate("com.example", "example-b"), "1.0")
+
+		advanceTimeBy(5.seconds)
+		runCurrent()
+		assertThat(versionNotifier.notifications).containsExactly(
+			"Maven Central com.example:example-a:1.0",
+			"CustomRepo com.example:example-b:1.0",
 		)
 
 		monitorJob.cancel()
@@ -87,8 +144,10 @@ class DependencyNotifierTest {
 
 	@Test fun monitorNotifiesLatestFirstTime() = runTest {
 		config.writeText("""
-			|coordinates:
-			| - com.example:example-a
+			|[MavenCentral]
+			|coordinates = [
+			|  "com.example:example-a",
+			|]
 		""".trimMargin())
 
 		val monitorJob = launch {
@@ -98,16 +157,16 @@ class DependencyNotifierTest {
 		runCurrent()
 		assertThat(versionNotifier.notifications).isEmpty()
 
-		val mavenRepository = mavenRepositories[MavenCentral]!!
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.1")
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.2")
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.3")
+		val mavenCentral = mavenRepositories[MavenCentralHost]!!
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.1")
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.2")
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.3")
 
 		advanceTimeBy(5.seconds)
 		runCurrent()
 		assertThat(versionNotifier.notifications).containsExactly(
-			"com.example:example-a:1.3",
+			"Maven Central com.example:example-a:1.3",
 		)
 
 		monitorJob.cancel()
@@ -115,8 +174,10 @@ class DependencyNotifierTest {
 
 	@Test fun monitorNotifiesAllNewSecondTime() = runTest {
 		config.writeText("""
-			|coordinates:
-			| - com.example:example-a
+			|[MavenCentral]
+			|coordinates = [
+			|  "com.example:example-a",
+			|]
 		""".trimMargin())
 
 		val monitorJob = launch {
@@ -126,25 +187,25 @@ class DependencyNotifierTest {
 		runCurrent()
 		assertThat(versionNotifier.notifications).isEmpty()
 
-		val mavenRepository = mavenRepositories[MavenCentral]!!
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.1")
+		val mavenCentral = mavenRepositories[MavenCentralHost]!!
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.1")
 
 		advanceTimeBy(5.seconds)
 		runCurrent()
 		assertThat(versionNotifier.notifications).containsExactly(
-			"com.example:example-a:1.1",
+			"Maven Central com.example:example-a:1.1",
 		)
 
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.2")
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.3")
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.2")
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.3")
 
 		advanceTimeBy(5.seconds)
 		runCurrent()
 		assertThat(versionNotifier.notifications).containsExactly(
-			"com.example:example-a:1.1",
-			"com.example:example-a:1.2",
-			"com.example:example-a:1.3",
+			"Maven Central com.example:example-a:1.1",
+			"Maven Central com.example:example-a:1.2",
+			"Maven Central com.example:example-a:1.3",
 		)
 
 		monitorJob.cancel()
@@ -152,13 +213,15 @@ class DependencyNotifierTest {
 
 	@Test fun monitorReadsConfigForEachCheck() = runTest {
 		config.writeText("""
-			|coordinates:
-			| - com.example:example-a
-		""".trimMargin())
+			|[MavenCentral]
+			|coordinates = [
+			|  "com.example:example-a",
+			|]
+			|""".trimMargin())
 
 		// Create and write the repo to the map so it's available on first run.
-		val mavenRepository = FakeMavenRepository().also { mavenRepositories[MavenCentral] = it }
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
+		val mavenCentral = FakeMavenRepository(MavenCentralName).also { mavenRepositories[MavenCentralHost] = it }
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-a"), "1.0")
 
 		val monitorJob = launch {
 			notifier.monitor(5.seconds)
@@ -166,27 +229,29 @@ class DependencyNotifierTest {
 
 		runCurrent()
 		assertThat(versionNotifier.notifications).containsExactly(
-			"com.example:example-a:1.0",
+			"Maven Central com.example:example-a:1.0",
 		)
 
 		// Add artifact to repo but not to config. Should not notify.
-		mavenRepository.addArtifact(MavenCoordinate("com.example", "example-b"), "2.0")
+		mavenCentral.addArtifact(MavenCoordinate("com.example", "example-b"), "2.0")
 		advanceTimeBy(5.seconds)
 		runCurrent()
 		assertThat(versionNotifier.notifications).containsExactly(
-			"com.example:example-a:1.0",
+			"Maven Central com.example:example-a:1.0",
 		)
 
 		config.writeText("""
-			|coordinates:
-			| - com.example:example-a
-			| - com.example:example-b
-		""".trimMargin())
+			|[MavenCentral]
+			|coordinates = [
+			|  "com.example:example-a",
+			|  "com.example:example-b",
+			|]
+			|""".trimMargin())
 		advanceTimeBy(5.seconds)
 		runCurrent()
 		assertThat(versionNotifier.notifications).containsExactly(
-			"com.example:example-a:1.0",
-			"com.example:example-b:2.0",
+			"Maven Central com.example:example-a:1.0",
+			"Maven Central com.example:example-b:2.0",
 		)
 
 		monitorJob.cancel()

--- a/src/test/kotlin/watch/dependency/FakeMavenRepository.kt
+++ b/src/test/kotlin/watch/dependency/FakeMavenRepository.kt
@@ -1,11 +1,10 @@
 package watch.dependency
 
-import okhttp3.mockwebserver.Dispatcher
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.RecordedRequest
 import watch.dependency.MavenRepository.Versions
 
-class FakeMavenRepository : MavenRepository {
+class FakeMavenRepository(
+	override val name: String,
+) : MavenRepository {
 	private val versions = mutableMapOf<MavenCoordinate, MutableList<String>>()
 
 	fun addArtifact(
@@ -23,35 +22,5 @@ class FakeMavenRepository : MavenRepository {
 			latest = coordinateVersions.last(),
 			all = coordinateVersions.toSet(),
 		)
-	}
-
-	fun asMockWebServerDispatcher(): Dispatcher = object : Dispatcher() {
-		override fun dispatch(request: RecordedRequest): MockResponse {
-			request.requestUrl?.let { url ->
-				if (url.pathSegments.size > 2 && url.pathSegments.last() == "maven-metadata.xml") {
-					val coordinateParts = url.pathSegments.dropLast(1)
-					val artifactId = coordinateParts.last()
-					val groupId = coordinateParts.dropLast(1).joinToString(".")
-					val coordinate = MavenCoordinate(groupId, artifactId)
-					val coordinateVersions = versions[coordinate]
-					if (coordinateVersions != null) {
-						// Build minimal XML subset to make HttpMaven2Repository happy.
-						return MockResponse()
-							.setBody(buildString {
-								append("<metadata><versioning><release>")
-								append(coordinateVersions.last())
-								append("</release><versions>")
-								for (version in coordinateVersions) {
-									append("<version>")
-									append(version)
-									append("</version>")
-								}
-								append("</versions></versioning></metadata>")
-							})
-					}
-				}
-			}
-			return MockResponse().setResponseCode(404)
-		}
 	}
 }

--- a/src/test/kotlin/watch/dependency/HttpMaven2RepositoryTest.kt
+++ b/src/test/kotlin/watch/dependency/HttpMaven2RepositoryTest.kt
@@ -11,10 +11,10 @@ import watch.dependency.MavenRepository.Versions
 
 class HttpMaven2RepositoryTest {
 	@get:Rule val server = MockWebServer()
+	private val repository =
+		MavenRepository.Factory.Http(OkHttpClient()).maven2("MWS", server.url("/"))
 
 	@Test fun simple() = runBlocking {
-		val repository = HttpMaven2Repository(OkHttpClient(), server.url("/"))
-
 		server.enqueue(MockResponse()
 			.setBody("""
 				|<metadata>
@@ -54,7 +54,6 @@ class HttpMaven2RepositoryTest {
 	}
 
 	@Test fun notFoundReturnsNull() = runBlocking {
-		val repository = HttpMaven2Repository(OkHttpClient(), server.url("/"))
 		server.enqueue(MockResponse().setResponseCode(404))
 		val version = repository.versions(MavenCoordinate("com.example", "example"))
 		assertThat(version).isNull()

--- a/src/test/kotlin/watch/dependency/IftttVersionNotifierTest.kt
+++ b/src/test/kotlin/watch/dependency/IftttVersionNotifierTest.kt
@@ -16,11 +16,11 @@ class IftttVersionNotifierTest {
 		val notifier = IftttVersionNotifier(OkHttpClient(), serverUrl)
 
 		server.enqueue(MockResponse())
-		notifier.notify(MavenCoordinate("com.example", "example"), "1.1.0")
+		notifier.notify("Repo", MavenCoordinate("com.example", "example"), "1.1.0")
 
 		val request = server.takeRequest()
 		assertThat(request.body.readUtf8())
-			.isEqualTo("""{"value1":"com.example:example","value2":"1.1.0"}""")
+			.isEqualTo("""{"value1":"Repo","value2":"com.example:example","value3":"1.1.0"}""")
 		assertThat(request.requestUrl).isEqualTo(serverUrl)
 	}
 }

--- a/src/test/kotlin/watch/dependency/RecordingVersionNotifier.kt
+++ b/src/test/kotlin/watch/dependency/RecordingVersionNotifier.kt
@@ -1,13 +1,14 @@
 package watch.dependency
 
 class RecordingVersionNotifier : VersionNotifier {
-  private val _notifications = mutableListOf<String>()
-  val notifications: List<String> = _notifications
+	private val _notifications = mutableListOf<String>()
+	val notifications: List<String> = _notifications
 
-  override suspend fun notify(
-    coordinate: MavenCoordinate,
-    version: String,
-  ) {
-    _notifications += "${coordinate.groupId}:${coordinate.artifactId}:$version"
-  }
+	override suspend fun notify(
+		repositoryName: String,
+		coordinate: MavenCoordinate,
+		version: String,
+	) {
+		_notifications += "$repositoryName ${coordinate.groupId}:${coordinate.artifactId}:$version"
+	}
 }


### PR DESCRIPTION
This changes the configuration format from YAML to TOML. It also changes the IFTTT values such that the first one is now the repository name with the coordinate and version becoming the second and third, respectively.

Closes #8.