### PR TITLE
Support HTTP proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM azul/zulu-openjdk:21-latest AS build
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 WORKDIR /app
 
-COPY gradlew settings.gradle .editorconfig ./
+COPY gradlew settings.gradle .editorconfig gradle.propertie[s] ./
 COPY gradle ./gradle
 RUN ./gradlew --version
 

--- a/src/main/kotlin/watch/dependency/main.kt
+++ b/src/main/kotlin/watch/dependency/main.kt
@@ -16,6 +16,9 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.switch
 import com.github.ajalt.clikt.parameters.types.path
 import com.github.ajalt.mordant.terminal.Terminal
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.URI
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import kotlin.time.Duration
@@ -66,6 +69,11 @@ private abstract class DependencyWatchCommand(
 			.apply {
 				if (debug.enabled) {
 					addNetworkInterceptor(HttpLoggingInterceptor(debug::log).setLevel(BASIC))
+				}
+				System.getenv("https_proxy")?.let {
+					URI.create(it).apply {
+						proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress(host, port)))
+					}
 				}
 			}
 			.build()


### PR DESCRIPTION
Fixes https://github.com/JakeWharton/dependency-watch/issues/156

When cloning this repository, this allows you to add a gradle.properties file to the Docker container before the Gradle distribution is downloaded.

So, Gradle properties like `systemProp.https.proxyHost` and `systemProp.https.proxyPort` can be set early enough for dependency-watch to be built inside networks that require a proxy.

When running the container, this also makes OkHttp use the `https_proxy` environment variable so dependency-watch can make successful requests to public Maven repositories from inside networks that require a proxy.
